### PR TITLE
update everything, remove upstreamed patches

### DIFF
--- a/appdata.patch
+++ b/appdata.patch
@@ -1,14 +1,14 @@
-diff --git a/iconexplorer/CMakeLists.txt b/iconexplorer/CMakeLists.txt
-index 2a388858..f7679fe7 100644
+diff --git i/iconexplorer/CMakeLists.txt w/iconexplorer/CMakeLists.txt
+index fd6a1440..f7679fe7 100644
 --- a/iconexplorer/CMakeLists.txt
 +++ b/iconexplorer/CMakeLists.txt
-@@ -4,4 +4,5 @@ if(BUILD_TESTING)
+@@ -4,5 +4,5 @@ if(BUILD_TESTING)
  endif()
  
  install(FILES org.kde.iconexplorer.desktop DESTINATION ${KDE_INSTALL_APPDIR})
 -install(FILES org.kde.plasma.iconexplorer.appdata.xml DESTINATION ${KDE_INSTALL_METAINFODIR})
 +install(FILES org.kde.iconexplorer.appdata.xml DESTINATION ${KDE_INSTALL_METAINFODIR})
-+install(FILES org.kde.iconexplorer.svg DESTINATION ${KDE_INSTALL_FULL_ICONDIR}/hicolor/scalable/apps)
+ install(FILES org.kde.iconexplorer.svg DESTINATION ${KDE_INSTALL_FULL_ICONDIR}/hicolor/scalable/apps)
 diff --git a/iconexplorer/org.kde.plasma.iconexplorer.appdata.xml b/iconexplorer/org.kde.iconexplorer.appdata.xml
 similarity index 99%
 rename from iconexplorer/org.kde.plasma.iconexplorer.appdata.xml
@@ -24,103 +24,3 @@ index 3a0ae27d..f3fd9391 100644
    <launchable type="desktop-id">org.kde.iconexplorer.desktop</launchable>
    <metadata_license>CC0-1.0</metadata_license>
    <project_license>GPL-2.0+</project_license>
-@@ -115,6 +115,9 @@
-   </description>
-   <url type="homepage">https://kde.org/plasma-desktop</url>
-   <url type="bugtracker">https://bugs.kde.org/enter_bug.cgi?format=guided&amp;product=Plasma%20SDK&amp;component=cuttlefish</url>
-+  <developer id="org.kde">
-+    <name translate="no">KDE</name>
-+  </developer>
-   <screenshots>
-     <screenshot type="default">
-       <image>https://www.kde.org/images/screenshots/cuttlefish.png</image>
-diff --git a/iconexplorer/org.kde.iconexplorer.desktop b/iconexplorer/org.kde.iconexplorer.desktop
-index c885c0e7..353789dd 100755
---- a/iconexplorer/org.kde.iconexplorer.desktop
-+++ b/iconexplorer/org.kde.iconexplorer.desktop
-@@ -159,7 +159,7 @@ Keywords[x-test]=xxdesignxx;xxiconxx;xxpreviewxx;xxsymbolxx;xxcuttlefishxx;
- Keywords[zh_CN]=design;icon;preview;symbol;cuttlefish;设计;图标;预览;符号;sheji;tubiao;yulan;fuhao;
- Keywords[zh_TW]=design;icon;preview;symbol;cuttlefish;圖示;預覽;設計;符號;
- Exec=iconexplorer
--Icon=cuttlefish
-+Icon=org.kde.iconexplorer
- Type=Application
- InitialPreference=7
- Categories=Qt;KDE;Development;IDE;
-diff --git a/iconexplorer/org.kde.iconexplorer.svg b/iconexplorer/org.kde.iconexplorer.svg
-new file mode 100644
-index 00000000..1158bb89
---- /dev/null
-+++ b/iconexplorer/org.kde.iconexplorer.svg
-@@ -0,0 +1,71 @@
-+<?xml version="1.0" encoding="UTF-8"?>
-+<svg id="svg29" width="256" height="256" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-+ <defs id="defs10">
-+  <linearGradient id="a" x1="390.08" x2="389.88" y1="534.08" y2="513.54" gradientTransform="matrix(-1.0825 .63333 -.625 -1.097 1174.6 852.48)" gradientUnits="userSpaceOnUse">
-+   <stop id="stop1" stop-color="#fcfcfc" offset="0"/>
-+   <stop id="stop2" stop-color="#b677d3" offset="1"/>
-+  </linearGradient>
-+  <linearGradient id="b" x1="382.21" x2="395.45" y1="532.43" y2="526.79" gradientTransform="matrix(1.0825 .63333 .625 -1.097 -357.51 852.48)" gradientUnits="userSpaceOnUse" xlink:href="#a"/>
-+  <linearGradient id="c" x1="25.13" x2="7.07" y1="20.16" y2="4.759" gradientTransform="matrix(1.25 0 0 1.2667 388.57 502.26)" gradientUnits="userSpaceOnUse">
-+   <stop id="stop3" stop-color="#c0392b" offset="0"/>
-+   <stop id="stop4" stop-color="#b677d3" offset="1"/>
-+  </linearGradient>
-+  <linearGradient id="d" x1="400.57" x2="392.9" y1="537.6" y2="546.58" gradientTransform="matrix(1.25 0 0 1.2667 -92.14 -151.08)" gradientUnits="userSpaceOnUse">
-+   <stop id="stop5" stop-color="#ffc35a" offset="0"/>
-+   <stop id="stop6" stop-color="#faae2a" offset="1"/>
-+  </linearGradient>
-+  <linearGradient id="e" x1="393.43" x2="390.56" y1="538.07" y2="539.31" gradientTransform="matrix(1.25 0 0 1.2667 -92.14 -151.08)" gradientUnits="userSpaceOnUse" xlink:href="#d"/>
-+  <linearGradient id="f" x1="390.57" x2="386.57" y1="535.36" y2="540.75" gradientTransform="matrix(1.25 0 0 1.2667 -92.14 -151.08)" gradientUnits="userSpaceOnUse">
-+   <stop id="stop7" stop-color="#fdbc4b" offset="0"/>
-+   <stop id="stop8" stop-color="#dde341" offset="1"/>
-+  </linearGradient>
-+  <linearGradient id="g" x1="393.1" x2="388.89" y1="524.44" y2="522.66" gradientTransform="matrix(.95819 .56059 .55321 -.97096 -270.72 815.18)" gradientUnits="userSpaceOnUse" xlink:href="#d"/>
-+  <linearGradient id="h" x1="392.69" x2="389.45" y1="522.9" y2="521.73" gradientTransform="matrix(-.95819 .56059 -.55321 -.97096 1087.9 815.18)" gradientUnits="userSpaceOnUse" xlink:href="#d"/>
-+  <linearGradient id="i" x1="390.57" x2="386.57" y1="535.36" y2="540.75" gradientTransform="matrix(-1.25 0 0 1.2667 909.29 -151.08)" gradientUnits="userSpaceOnUse" xlink:href="#d"/>
-+  <linearGradient id="j" x1="393.43" x2="390.56" y1="538.07" y2="539.31" gradientTransform="matrix(-1.25 0 0 1.2667 909.29 -151.08)" gradientUnits="userSpaceOnUse" xlink:href="#d"/>
-+  <linearGradient id="k" x1="400.57" x2="392.9" y1="537.6" y2="546.58" gradientTransform="matrix(-1.25 0 0 1.2667 909.29 -151.08)" gradientUnits="userSpaceOnUse" xlink:href="#d"/>
-+  <linearGradient id="l" x1="396.57" x2="389.57" y1="535.8" y2="542.8" gradientTransform="matrix(-1.25 0 0 1.2667 909.29 -152.35)" gradientUnits="userSpaceOnUse">
-+   <stop id="stop9" offset="0"/>
-+   <stop id="stop10" stop-opacity="0" offset="1"/>
-+  </linearGradient>
-+  <linearGradient id="m" x1="396.57" x2="389.57" y1="535.8" y2="542.8" gradientTransform="matrix(-1.25 0 0 1.2667 914.29 -151.08)" gradientUnits="userSpaceOnUse" xlink:href="#l"/>
-+  <linearGradient id="n" x1="396.57" x2="389.57" y1="535.8" y2="542.8" gradientTransform="matrix(-1.25 0 0 1.2667 919.29 -151.08)" gradientUnits="userSpaceOnUse" xlink:href="#l"/>
-+  <linearGradient id="o" x1="396.57" x2="384.57" y1="535.8" y2="547.8" gradientTransform="matrix(-1.25 0 0 1.2667 890.54 -167.55)" gradientUnits="userSpaceOnUse" xlink:href="#l"/>
-+  <linearGradient id="p" x1="390.57" x2="386.57" y1="535.36" y2="540.75" gradientTransform="matrix(1.25 0 0 1.2667 -92.14 -151.08)" gradientUnits="userSpaceOnUse" xlink:href="#d"/>
-+  <path id="q" d="m394.82 525.06c-3.75 2.533 0 5.067-2.5 7.6s-3.75 1.267-3.75 2.533c0 1.267 3.75 3.8 6.25 1.267s2.5-3.8 2.5-3.8 2.5-2.533 1.25-5.067c-1.25-2.533-3.75-2.533-3.75-2.533" fill-rule="evenodd"/>
-+  <linearGradient id="linearGradient29" x1="390.08" x2="389.88" y1="534.08" y2="513.54" gradientTransform="matrix(-1.0825 .63333 -.625 -1.097 1174.6 852.48)" gradientUnits="userSpaceOnUse" xlink:href="#a"/>
-+  <linearGradient id="linearGradient30" x1="396.57" x2="389.57" y1="535.8" y2="542.8" gradientTransform="matrix(-1.25 0 0 1.2667 909.29 -152.35)" gradientUnits="userSpaceOnUse" xlink:href="#l"/>
-+  <linearGradient id="linearGradient31" x1="400.57" x2="392.9" y1="537.6" y2="546.58" gradientTransform="matrix(1.25 0 0 1.2667 -92.14 -151.08)" gradientUnits="userSpaceOnUse" xlink:href="#d"/>
-+ </defs>
-+ <g id="g29" transform="matrix(6.2 0 0 6.5263 -2405.1 -3290.5)">
-+  <path id="path10" d="m408.57 504.8c9.695 0 17.5 7.909 17.5 17.733s-7.805 11.4-17.5 11.4-17.5-1.576-17.5-11.4 7.805-17.733 17.5-17.733" fill="#ffc35a"/>
-+  <path id="path11" d="m408.57 504.8c-0.071 0-0.139 9e-3 -0.21 0.01-0.664 1.956-0.025 4.47 1.238 5.079 1.36 0.656 4.33-0.672 5.269-2.669 0.179-0.381 0.249-0.756 0.271-1.123-2.028-0.829-4.24-1.296-6.567-1.296m-1.167 0.059c-2.719 0.181-5.26 0.978-7.495 2.266 0.245 0.656 0.758 1.223 1.533 1.672 1.699 0.985 4.65 1.139 5.713-0.742 0.484-0.857 0.508-2.053 0.249-3.196m8.281 2.934c-0.611 0-2.212 1.25-2.212 1.804 0 0.553 1.286 1.962 1.897 1.962s0.396-1.891 0.396-2.444 0.531-1.321-0.081-1.321m-13.308 1.705c-0.811-0.075-1.932 0.833-2.202 1.338-0.309 0.577-0.331 2.083 0.469 2.523s1.497-0.553 1.807-1.131c0.309-0.577 1.051-2.195 0.251-2.635-0.1-0.055-0.209-0.086-0.325-0.097m4.919 0.198c-0.887 0.012-1.896 0.305-2.727 0.698-1.662 0.785-1.984 2.786-1.301 4.27 0.682 1.484 1.636 2.049 3.298 1.264s3.405-3.746 2.722-5.23c-0.341-0.742-1.105-1.013-1.992-1m4.724 0.668c-0.359 0.03-0.735 0.146-1.125 0.356-1.56 0.843-2.106 3.304-1.316 4.807s2.934 2.28 4.495 1.437c1.56-0.843 1.315-3.385 0.525-4.889-0.593-1.127-1.502-1.801-2.578-1.712m4.451 2.264c-0.908 0.056-0.979 1.272-0.94 1.927 0.039 0.656 0.254 2.426 1.162 2.37s1.533-1.754 1.494-2.41-0.808-1.943-1.716-1.888m-8.787 3.434c-1.207-0.019-2.527 0.835-3.123 1.749-0.794 1.218-1.184 2.238 0.2 3.164 1.384 0.927 3.544 0.77 4.338-0.448s1.106-3.197-0.278-4.124c-0.346-0.232-0.735-0.335-1.138-0.341m-4.121 0.304c-0.495 0-1.213 0.378-1.213 1.042s0.323 0.96 0.818 0.96 0.977-0.296 0.977-0.96-0.086-1.042-0.581-1.042m7.893 1.442c-0.764 0-1.462 1.473-1.462 2.402s1.013 0.962 1.777 0.962 1.78-0.753 1.78-1.682-1.331-1.682-2.095-1.682" fill="url(#c)"/>
-+  <path id="path12" d="m392.08 527.72a5.0043 8.859 14.634 0 1-2.565-9.8759 5.0043 8.859 14.634 0 1 7.0943-7.2532 5.0043 8.859 14.634 0 1 0.54755 0.22338 5.0044 17.718 14.778 0 1-1.6048 8.669 5.0044 17.718 14.778 0 1-2.8915 8.3256 5.0043 8.859 14.634 0 1-0.58058-0.089" fill="url(#b)"/>
-+  <path id="path13" d="m389.05 520.61a5.0043 8.859 14.634 0 1 0.46123-2.764 5.0043 8.859 14.634 0 1 0.22806-0.76642c1.716 0.231 1.755-0.194 2.705-0.383 1.06-0.211 3.047 1.789 1.328 1.488-1.718-0.301-2.221 2.466-4.558 2.438-0.072-1e-3 -0.097-0.011-0.164-0.013" color="#000000" color-rendering="auto" fill="#2c3e50" fill-rule="evenodd" image-rendering="auto" shape-rendering="auto" text-rendering="auto"/>
-+  <path id="path14" d="m425.06 527.72a8.859 5.0043 75.366 0 0 2.565-9.8759 8.859 5.0043 75.366 0 0-7.0943-7.2532 8.859 5.0043 75.366 0 0-0.54755 0.22338 17.718 5.0044 75.222 0 0 1.6048 8.669 17.718 5.0044 75.222 0 0 2.8915 8.3256 8.859 5.0043 75.366 0 0 0.58058-0.089" fill="url(#linearGradient29)"/>
-+  <g id="g19" fill-rule="evenodd">
-+   <path id="path15" d="m428.09 520.61a8.859 5.0043 75.366 0 0-0.46122-2.764 8.859 5.0043 75.366 0 0-0.22806-0.76642c-1.716 0.231-1.755-0.194-2.705-0.383-1.06-0.211-3.047 1.789-1.328 1.488 1.718-0.301 2.221 2.466 4.558 2.438 0.072-1e-3 0.097-0.011 0.164-0.013" color="#000000" color-rendering="auto" fill="#2c3e50" image-rendering="auto" shape-rendering="auto" text-rendering="auto"/>
-+   <g id="g17" fill="#ffc35a">
-+    <path id="path16" d="m399.91 508.61s-5-1.267-5 1.267c0 1.267 1.25 5.067 1.25 7.6s2.5-3.8 2.5-3.8z"/>
-+    <path id="path17" d="m417.32 508.6s5-1.267 5 1.267c0 1.267-1.25 5.067-1.25 7.6s-2.5-3.8-2.5-3.8z"/>
-+   </g>
-+   <path id="path18" d="m394.51 530.13s-4.386-1.271-3.28-3.213c0.553-0.971 3.171-3.323 4.277-5.265s0.257 4.03 0.257 4.03z" fill="url(#g)"/>
-+   <path id="path19" d="m422.64 530.13s4.386-1.271 3.28-3.213c-0.553-0.971-3.171-3.323-4.277-5.265s-0.257 4.03-0.257 4.03z" fill="url(#h)"/>
-+  </g>
-+  <use id="use19" fill="url(#f)" xlink:href="#q"/>
-+  <g id="g25" fill-rule="evenodd">
-+   <path id="path20" d="m423.57 526.33v3.459c0.697-0.284 1.578-0.739 2.097-1.333z" fill="url(#n)" opacity=".1"/>
-+   <path id="path21" d="m422.32 525.06c3.75 2.533 0 5.067 2.5 7.6s3.75 1.267 3.75 2.533c0 1.267-3.75 3.8-6.25 1.267s-2.5-3.8-2.5-3.8-2.5-2.533-1.25-5.067c1.25-2.533 3.75-2.533 3.75-2.533" fill="url(#i)"/>
-+   <path id="path22" d="m419.05 526.82c-0.173 0.23-0.338 0.483-0.483 0.777v3.097c0.47 1.154 1.25 1.969 1.25 1.969s0 1.267 2.5 3.8c2.01 2.04 4.804 0.796 5.828-0.428l-3.328-3.372z" fill="url(#m)" opacity=".1"/>
-+   <path id="path23" d="m415.11 537.93c0.971 3.671 6.827 4.075 8.466 2.338s-1.782-1.53-2.429-3.977 0.884-1.551-0.087-5.222-3.734-6-3.734-6l-5 2.533z" fill="url(#j)"/>
-+   <path id="path24" d="m413.82 526.33-0.25 0.633v5.272l1.533 5.69c0.971 3.671 6.828 4.075 8.467 2.338s-1.752-1.536-2.429-3.976c-0.474-1.707 0.059-1.653 0.137-2.415z" fill="url(#linearGradient30)" opacity=".1"/>
-+   <path id="path25" d="m408.57 531.4v5.067c0 3.8 3.75 6.333 7.5 6.333s-1.25-2.533 0-6.333-2.5-11.4-2.5-11.4l-5 1.267z" fill="url(#k)"/>
-+  </g>
-+  <use id="use25" fill="url(#p)" xlink:href="#q"/>
-+  <g id="g28" fill-rule="evenodd">
-+   <path id="path26" d="m402.04 537.93c-0.971 3.671-6.827 4.075-8.466 2.338s1.782-1.53 2.429-3.977-0.884-1.551 0.087-5.222 3.734-6 3.734-6l5 2.533z" fill="url(#e)"/>
-+   <path id="path27" d="m408.57 531.4v5.067c0 3.8-3.75 6.333-7.5 6.333s1.25-2.533 0-6.333 2.5-11.4 2.5-11.4l5 1.267z" fill="url(#linearGradient31)"/>
-+   <path id="path28" d="m394.92 509.97c0.038 1.255 1.098 4.611 1.216 7.083a5.0044 17.718 14.778 0 1-0.58594 2.4319 5.0044 17.718 14.778 0 1-1.0986 3.6689c-1.23 1.529-2.812 3.038-3.228 3.768-0.013 0.023-0.013 0.044-0.024 0.067l-0.129 0.614 0.688 1.163c0.417 0.353 0.947 0.638 1.438 0.861 0.12 1.014 0.125 2.029-0.876 3.043-2.5 2.533-3.75 1.267-3.75 2.533 0 1.267 3.75 3.8 6.25 1.267 0.565-0.572 0.987-1.071 1.326-1.514 0.038 0.318 0.016 0.723-0.146 1.338-0.647 2.447-4.068 2.239-2.429 3.976s7.496 1.333 8.467-2.338l1.143-4.243c1.699 0.172 3.501 0.247 5.391 0.247 3.365 0 6.491-0.2 9.153-0.858z" fill="url(#o)" opacity=".1"/>
-+  </g>
-+ </g>
-+</svg>

--- a/org.kde.iconexplorer.yml
+++ b/org.kde.iconexplorer.yml
@@ -20,8 +20,8 @@ modules:
     buildsystem: cmake-ninja
     sources:
       - type: archive
-        url: https://download.kde.org/stable/plasma/6.2.4/libplasma-6.2.4.tar.xz
-        sha256: 66eda145fb57dcc585db97fd7e543f2cdfc745ceb83c16cbe3d080939f5b1b14
+        url: https://download.kde.org/stable/plasma/6.5.3/libplasma-6.5.3.tar.xz
+        sha256: 1fe40f488501078dc700f3ca018e4ff5d4c5d344fbcd4adb76ace86269c7a9f5
         x-checker-data:
           type: anitya
           project-id: 8761
@@ -58,8 +58,8 @@ modules:
       - -DENABLE_KAUTH_HELPER=OFF
     sources:
       - type: archive
-        url: https://download.kde.org/stable/plasma/6.2.4/libksysguard-6.2.4.tar.xz
-        sha256: f799f90efd3b3e0ea17b1969bb0cc5744c7762ea16d128b1b4d31dfa78cc58ae
+        url: https://download.kde.org/stable/plasma/6.5.3/libksysguard-6.5.3.tar.xz
+        sha256: eb8d01fbcf6410a9d5ae78c538392524e20bbf4dc0a9619a3732a4731d5e7187
         x-checker-data:
           type: anitya
           project-id: 8761
@@ -69,8 +69,8 @@ modules:
     buildsystem: cmake-ninja
     sources:
       - type: archive
-        url: https://download.kde.org/stable/plasma/6.2.4/plasma5support-6.2.4.tar.xz
-        sha256: 233bbdc3f1c0b8acbb710f53c6308359c315b699958f6784b3467f4724f93d8d
+        url: https://download.kde.org/stable/plasma/6.5.3/plasma5support-6.5.3.tar.xz
+        sha256: b58bb7bcb5914e3f3c76d3de920d953c8791f0f9a8e2d6eb841051b18009797f
         x-checker-data:
           type: anitya
           project-id: 8761
@@ -81,8 +81,8 @@ modules:
     builddir: true
     sources:
       - type: archive
-        url: https://download.kde.org/stable/plasma/6.2.4/plasma-sdk-6.2.4.tar.xz
-        sha256: 576f6aa751d9d2cf66cdf09562ce86ed02cbbf73e5ae5ccbd06e01f8163b8878
+        url: https://download.kde.org/stable/plasma/6.5.3/plasma-sdk-6.5.3.tar.xz
+        sha256: 0e8b0b63799bb78555bbcd88e3f804511deeb56278588545460e8c7942de0fdf
         x-checker-data:
           type: anitya
           project-id: 8761

--- a/org.kde.iconexplorer.yml
+++ b/org.kde.iconexplorer.yml
@@ -14,7 +14,9 @@ cleanup:
   - /include
   - /lib/cmake
   - /lib/libexec
+  - /lib/pkgconfig
   - /mkspecs
+
 modules:
   - name: libplasma
     buildsystem: cmake-ninja

--- a/org.kde.iconexplorer.yml
+++ b/org.kde.iconexplorer.yml
@@ -1,6 +1,6 @@
 app-id: org.kde.iconexplorer
 runtime: org.kde.Platform
-runtime-version: 6.9
+runtime-version: 6.10
 sdk: org.kde.Sdk
 command: iconexplorer
 copy-icon: true


### PR DESCRIPTION
brings in
https://github.com/flathub/org.kde.iconexplorer/pull/11
https://github.com/flathub/org.kde.iconexplorer/pull/9

and removes the upstreamed patches